### PR TITLE
Fix citation (bibtex) plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,11 +91,11 @@ plugins:
       archive_url_date_format: yyyy/MM
   - git-revision-date-localized:
       type: timeago
-#  - bibtex:
-#      bib_file: "docs/assets/library.bib"
-#      bib_by_default: true
-#      csl_file: "docs/assets/harvard-imperial.csl"
-#      cite_inline: true
+  - bibtex:
+      bib_file: "docs/assets/library.bib"
+      bib_by_default: true
+      csl_file: "docs/assets/harvard-imperial.csl"
+      enable_inline_citations: true
 #  - minify:
 #      minify_html: true
 #      minify_js: true


### PR DESCRIPTION
## 問題

`[@key]` 格式的引用都沒有渲染——`mkdocs-bibtex` plugin 完全沒運作。實際上有三個獨立問題疊在一起：

1. **Plugin 在 `mkdocs.yml` 裡被註解掉了**（行 94–98），所以 `[@Mermel2009ClinicalPractice]` 這類語法被當成原字串輸出。
2. **`cite_inline` 選項已棄用**——`mkdocs-bibtex` 4.x 改名成 `enable_inline_citations`，舊名稱會被忽略並噴 warning。
3. **`docs/assets/library.bib` 內含 pybtex 無法解析的條目**，會在啟動時直接 crash：
    - 217 個作者欄位用了 biblatex 擴充格式（`family=Souza, given=Gabriel, prefix=de, useprefix=true`），pybtex 不支援。
    - 三筆作者欄位語法損壞：`León-Ponte,, Matilde`（多一個逗號）、`Morvan1996` 的 `Bonnemoy *,  ,` 含控制字元、`Tandon2016` 用分號當分隔符。

## 修改

- `mkdocs.yml`：取消註解 `bibtex` plugin，並把 `cite_inline` 改成 `enable_inline_citations`。
- `docs/assets/library.bib`：
    - 把 217 個 biblatex 擴充姓名格式轉成傳統 BibTeX（`de Souza, Gabriel Samir Martins`）。
    - 修掉 León-Ponte、Bonnemoy/Morvan1996、Tandon2016 三筆損壞條目。

## 驗證

`mkdocs build` 完成沒有 error，產出的 HTML 可以看到 inline 引用（如 `(Mermel et al., 2009)`）以及對應的參考書目條目。

## Test plan

- [ ] `pip install -r requirements.txt`
- [ ] `mkdocs build`（或 `mkdocs serve`）跑完無 error
- [ ] 隨機檢查使用 `[@key]` 的頁面（例如 `docs/posts/bacteremia.md`、`docs/posts/ltbi.md`）渲染後出現引用與書目

https://claude.ai/code/session_01SoBUwyydpyuhecepYii73D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoBUwyydpyuhecepYii73D)_