### PR TITLE
Install pandoc in CI for mkdocs-bibtex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: Install pandoc
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+
       - name: Install dependencies
         run: pip install -r requirements.txt
 


### PR DESCRIPTION
## 問題

PR #266 合併後 `gh-deploy` 在 GitHub Actions 失敗：

```
OSError: No pandoc was found: either install pandoc and add it
to your PATH or or call pypandoc.download_pandoc(...)
```

`mkdocs-bibtex` 在使用 CSL file 時需要 pandoc，runner 預設沒裝。

## 修改

在 `.github/workflows/ci.yml` 的 `pip install` 之前加一步 `apt-get install pandoc`。

https://claude.ai/code/session_01SoBUwyydpyuhecepYii73D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoBUwyydpyuhecepYii73D)_