### PR TITLE
add daily digest 2026-05-15

### DIFF
--- a/docs/posts/2026-05-15.md
+++ b/docs/posts/2026-05-15.md
@@ -1,0 +1,32 @@
+---
+tags: [TransplantID, OneHealth, FoodSecurity, share]
+date: 2026-05-15
+share: true
+categories: [medicine, journal-digest]
+---
+
+# Daily Journal Digest — 2026-05-15
+
+> 過去 24 小時新增：Transplant ID × 0、One Health × 0、Food Security × 0，共 0 篇。
+
+<!-- more -->
+
+## 🔴 Transplant & Opportunistic Infections
+
+> 今日無符合條件的新文章。
+
+---
+
+## 🟢 One Health / Zoonoses
+
+> 今日無符合條件的新文章。
+
+---
+
+## 🟡 Food Security / Food Safety
+
+> 今日無符合條件的新文章。
+
+---
+
+*資料來源：PubMed (articles retrieved 2026-05-15)*


### PR DESCRIPTION
## Daily Medical Literature Digest — 2026-05-15

Publishes today's digest. PubMed had no new entries indexed for edat=2026-05-15; all sections show placeholder messages.

## Changes
- `docs/posts/2026-05-15.md` — digest post

---
_Generated by [Claude Code](https://claude.ai/code/session_01N15curAo8LnkTArV9fQAzT)_