### PR TITLE
add 2026-W21 weekly journal digest

### DIFF
--- a/docs/posts/2026-W21.md
+++ b/docs/posts/2026-W21.md
@@ -1,0 +1,797 @@
+---
+tags: [ID, hematology, share]
+date: 2026-05-24
+week: 2026-W21
+share: true
+categories: [medicine, journal-digest]
+---
+
+# Weekly Journal Digest — 2026-W21
+
+> 資料來源：PubMed（edat 過濾，2026-05-18 至 2026-05-24）。涵蓋期刊：Clin Infect Dis、Emerg Infect Dis、MMWR、N Engl J Med（Originals + Reviews，無主題過濾）、Transpl Infect Dis、Blood。共 39 篇（另排除 2 篇 Blood 更正紀錄）。NEJM Cases / Images / Perspective / Correspondence 由本月 NEJM ID 與 Hema/Onc 月報（Gmail）補完。
+
+<!-- more -->
+
+## Clin Infect Dis
+
+### Population sensitive linezolid monitoring during global implementation of BPaL based regimens
+**Authors**: Mao G et al. | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.1093/cid/ciag331](https://doi.org/10.1093/cid/ciag331)
+**TL;DR**: 探討在 BPaL（bedaquiline、pretomanid、linezolid）方案推廣期間，如何以族群敏感度藥物監測（population-sensitive TDM）優化 linezolid 劑量，以減少毒性並維持療效。
+
+> **嘻嘻**：BPaL 是廣泛性抗藥結核的希望，TDM 讓 linezolid 用得更安全——嘻嘻！
+
+---
+
+### Use of Dolutegravir for treatment of HTLV-1
+**Authors**: Brites C et al. | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.1093/cid/ciag324](https://doi.org/10.1093/cid/ciag324)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）
+
+> **嘻嘻**：Dolutegravir 跨刀對付 HTLV-1 retrovirus——整合酶抑制劑的跨界應用，科學總是出人意表——嘻嘻！
+
+---
+
+### Use of dolutegravir to treat people living with HTLV-1-associated myelopathy (HAM)
+**Authors**: Casseb J et al. | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.1093/cid/ciag323](https://doi.org/10.1093/cid/ciag323)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）
+
+> **嘻嘻**：HAM/TSP 的治療選項如此稀缺，dolutegravir 每個嘗試都值得關注——嘻嘻（謹慎版）！
+
+---
+
+### Can Influenza virus cause bacteremia, sepsis, and septic shock?
+**Authors**: Kalil AC et al. | **Type**: Journal Article | **Date**: 2026-04-21
+**DOI**: [10.1093/cid/ciag243](https://doi.org/10.1093/cid/ciag243)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）
+
+> **不嘻嘻**：流感可能引發菌血症？本來已經夠慘了，還要多慮細菌入血——不嘻嘻！
+
+---
+
+### Safari Souvenir: A Case of Fever in a Returning Traveler
+**Authors**: Kusnik NL et al. | **Type**: Journal Article | **Date**: 2026-05-20
+**DOI**: [10.1093/cid/ciag129](https://doi.org/10.1093/cid/ciag129)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）出去玩帶回來發燒的旅遊醫學病例。
+
+> **不嘻嘻**：Safari 紀念品裡夾帶發燒——旅遊醫學永遠不缺好故事，對病人而言不嘻嘻！
+
+---
+
+### Crusted, Chronic, and Confusing
+**Authors**: Hurtado-Rossi L et al. | **Type**: Journal Article | **Date**: 2026-05-20
+**DOI**: [10.1093/cid/ciaf583](https://doi.org/10.1093/cid/ciaf583)
+**TL;DR**: 慢性潰瘍性病灶反覆被診斷為細菌性蜂窩組織炎，最終確診為皮膚型 leishmaniasis（cutaneous leishmaniasis）。本案例強調持續性潰瘍應考慮地方性流行病暴露史，菌種鑑定對選擇治療方案至關重要。
+
+> **不嘻嘻**：蜂窩組織炎一再復發？也許是時候問問病人有沒有去過熱帶叢林——不嘻嘻（診斷延誤的代價）！
+
+---
+
+### Diagnostic Pitfalls—When First Appearances Can Deceive
+**Authors**: Caldwell A et al. | **Type**: Journal Article | **Date**: 2026-05-20
+**DOI**: [10.1093/cid/ciag044](https://doi.org/10.1093/cid/ciag044)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）
+
+> **嘻嘻**：第一印象不總是對的——診斷陷阱永遠值得被討論！
+
+---
+
+### Prevalence and outcomes of bacterial co-detections by blood culture among children and adults hospitalized with laboratory-confirmed influenza, 2022–2024
+**Authors**: Tenforde MW et al. | **Type**: Journal Article | **Date**: 2026-05-20
+**DOI**: [10.1093/cid/ciag242](https://doi.org/10.1093/cid/ciag242)
+**TL;DR**: FluSurv-NET 網路 2022–2024 兩個流感季資料，住院流感患者中 50.8% 有取血液培養，5.2% 有陽性細菌 co-detection。最常見病原為 Staphylococcus aureus（22.1%）及 Streptococcus pneumoniae（7.5%），兩者院內死亡率均達 22.4%。有超過 1 株細菌 co-detection 的患者 ICU 住院率 47.9%，院內死亡率 14.5%，遠高於無共感染者（1.5%）。
+
+> **不嘻嘻**：流感加菌血症＝雙重災難，ICU 和死亡率爆炸性上升——不嘻嘻！打疫苗能同時預防兩件事，快去打！
+
+---
+
+### Virological Response Versus Clinical Benefit in HAM/TSP
+**Authors**: Araujo AQ et al. | **Type**: Journal Article | **Date**: 2026-05-18
+**DOI**: [10.1093/cid/ciag319](https://doi.org/10.1093/cid/ciag319)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）
+
+> **嘻嘻**：病毒學反應不等於臨床改善——這個問題在 HAM/TSP 領域很重要，討論本身就是進步！
+
+---
+
+### The role of dolutegravir on therapy of HTLV-1 infection
+**Authors**: Brites C et al. | **Type**: Journal Article | **Date**: 2026-05-18
+**DOI**: [10.1093/cid/ciag320](https://doi.org/10.1093/cid/ciag320)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）
+
+> **嘻嘻**：本週 CID 的 HTLV-1/dolutegravir 小叢集——看來這個議題正在發酵中！
+
+---
+
+## Emerg Infect Dis
+
+> 今日無符合條件的新文章。
+
+---
+
+## MMWR Morb Mortal Wkly Rep
+
+### Prevalence and Context of Sunburn Among U.S. Adults — United States, 2024
+**Authors**: Holman DM et al. | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.15585/mmwr.mm7519a2](https://doi.org/10.15585/mmwr.mm7519a2)
+**TL;DR**: 2024 年全國健康訪問調查顯示，35.1%（約 8,810 萬）美國成年人過去一年至少曬傷一次，7.5% 曬傷四次以上。最常見曬傷情境為在水邊活動（60.6%），其次為運動（24.7%）及飲酒（17.6%）。約 55.1% 的人曬傷時有使用防曬乳。
+
+> **不嘻嘻**：超過一半的曬傷發生在有塗防曬乳的情況下——是防曬乳沒用，還是大家都塗法不對？——不嘻嘻！
+
+---
+
+### Klebsiella pneumoniae Carbapenemase-Producing Enterobacterales Infection and Colonization in a Long-Term Care Facility — Ontario, Canada, 2024–2025
+**Authors**: Aloosh M et al. | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.15585/mmwr.mm7519a1](https://doi.org/10.15585/mmwr.mm7519a1)
+**TL;DR**: 加拿大安大略省一家長照機構（LTCF）爆發 KPC（Klebsiella pneumoniae carbapenemase）產酶腸桿菌科（CPE）感染及定植疫情，源頭為一年前入住卻未執行適當感控措施的患者。全基因組定序確認疫情關聯，迅速實施接觸隔離、員工分組、環境清潔，才成功阻斷傳播。
+
+> **不嘻嘻**：一個沒有適當篩查的患者，讓整個病房中鏢——入住長照機構前的風險篩查真的非常重要——不嘻嘻！
+
+---
+
+## Transpl Infect Dis
+
+### Mpox in Solid Organ Transplant Recipients: Lessons from a Single-Center Case Series in South Florida
+**Authors**: Osman-Kardash L et al. | **Type**: Letter | **Date**: 2026-05-22
+**DOI**: [10.1111/tid.70246](https://doi.org/10.1111/tid.70246)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）南佛羅里達單中心病例系列，報告實體器官移植（SOT）接受者感染 mpox 的臨床特點與處置心得。
+
+> **不嘻嘻**：移植病人免疫抑制，mpox 來了更難處理——打疫苗才是上策——不嘻嘻！
+
+---
+
+### Preventing Cat-Astrophe: Toxoplasma Seroprevalence and Prophylaxis Adherence After Allogeneic Stem Cell Transplant
+**Authors**: Metlapalli M et al. | **Type**: Letter | **Date**: 2026-05-22
+**DOI**: [10.1111/tid.70222](https://doi.org/10.1111/tid.70222)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）報告同種異體幹細胞移植（allo-SCT）後 Toxoplasma 血清盛行率及預防藥物遵從性。
+
+> **嘻嘻**：標題叫「Preventing Cat-Astrophe」——光是看見貓咪雙關語就已經嘻嘻了！
+
+---
+
+### Infectious Risk Donor Status in Uncontrolled Donation After Circulatory Death and Liver Transplantation
+**Authors**: Lazzeri C et al. | **Type**: Journal Article | **Date**: 2026-05-22
+**DOI**: [10.1111/tid.70248](https://doi.org/10.1111/tid.70248)
+**TL;DR**: 52 例非控制型循環停止後捐贈（uDCD）供體分析，16 例（31%）血液培養陽性，但均為革蘭氏陽性球菌且判為污染物，無一在受者中分離出相同病原。24 名肝臟移植受者均未發生供者源性感染（donor-derived infection）。結論：uDCD 感染傳播風險低，但需系統性評估流程。
+
+> **嘻嘻**：緊急情況下器官品質比想像中好——多一個器官來源，嘻嘻！
+
+---
+
+### Invalid Nucleic Acid Test Results May Limit Deceased Donor Organ Utilization
+**Authors**: Dionne S et al. | **Type**: Journal Article | **Date**: 2026-05-22
+**DOI**: [10.1111/tid.70247](https://doi.org/10.1111/tid.70247)
+**TL;DR**: 美國 11 間器官捐贈檢驗實驗室分析，無效 discriminatory NAT（dNAT）結果發生率 0.027%（n=27），主要為疑似 HCV 感染（22 例）。無效結果導致報告延遲中位 22 小時，30% 案例因此器官未被移植。
+
+> **不嘻嘻**：0.027% 看似極少，但每一個無效 NAT 背後可能就是一個等待器官的生命——不嘻嘻！需要標準化報告流程及快速替代確認檢驗。
+
+---
+
+### Possible Donor-Derived Tuberculosis in an Orthotopic Heart Transplant Recipient
+**Authors**: Akella PV et al. | **Type**: Letter | **Date**: 2026-05-21
+**DOI**: [10.1111/tid.70243](https://doi.org/10.1111/tid.70243)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）報告一例可能的供者源性 Mycobacterium tuberculosis 感染，發生在正位心臟移植受者身上。
+
+> **不嘻嘻**：心臟移植後還要擔心結核——供者篩查和受者監測都不能鬆懈——不嘻嘻！
+
+---
+
+### Intermittent Letermovir Dosing in Cytomegalovirus High-Risk Liver Transplant Recipients May Facilitate Development of Cell-Mediated Immunity and Prevent Post-Prophylaxis Infection
+**Authors**: Kleiboeker HL et al. | **Type**: Letter | **Date**: 2026-05-19
+**DOI**: [10.1111/tid.70244](https://doi.org/10.1111/tid.70244)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）探討間歇性 letermovir 給藥策略在 CMV 高風險肝臟移植受者中，是否能在預防期後 CMV 感染的同時促進細胞免疫建立。
+
+> **嘻嘻**：間歇給藥讓免疫系統有機會「練習」對抗 CMV——這邏輯有趣，嘻嘻！
+
+---
+
+## Blood
+
+### In vivo gene therapy with CAR-T cells
+**Authors**: Wagner DL et al. | **Type**: Journal Article | **Date**: 2026-05-22
+**DOI**: [10.1182/blood.2025031898](https://doi.org/10.1182/blood.2025031898)
+**TL;DR**: 綜述 in vivo CAR-T 細胞基因治療的臨床概念驗證——直接在體內生成 CAR-T 細胞，省去複雜的體外製造流程。近期臨床報告初步顯示可行性及治療潛力，但仍面臨技術、生物學及安全性挑戰。
+
+> **嘻嘻**：CAR-T 的「隨插即用」版本，如果成功將大幅降低取得門檻——嘻嘻到不行！
+
+---
+
+### Venetoclax Plus Pediatric Regimen in Adolescents and Adults with Ph-Negative Acute Lymphoblastic Leukemia
+**Authors**: Gong X et al. | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.1182/blood.2026033577](https://doi.org/10.1182/blood.2026033577)
+**TL;DR**: 前瞻性 phase 2 研究，167 名 14–60 歲新診斷 Ph 陰性 ALL 患者接受 venetoclax 合併小兒化療方案。完全緩解率 91%，73% 達 multiparameter flow cytometry MRD 陰性，達主要終點。中位追蹤 19.3 個月，估計 2 年存活率 78.5%，與歷史對照相比有顯著改善，毒性相當。
+
+> **嘻嘻**：Venetoclax 加入小兒方案後效果亮眼，Ph- ALL 治療又進一步——嘻嘻！
+
+---
+
+### N6-methyladenosine reader IGF2BP2 in T-cell lymphoma
+**Authors**: Hu S et al. | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.1182/blood.2026034186](https://doi.org/10.1182/blood.2026034186)
+**TL;DR**: IGF2BP2（m6A reader 蛋白）在周邊 T 細胞淋巴瘤（PTCL）普遍高表現。機制上，IGF2BP2 穩定胞內體相關基因（RAB4、VPS35、RAB9、STAM），增強內吞作用，促進腫瘤增殖並抑制 CD8+ T 細胞浸潤。靶向 IGF2BP2 的小分子 CWI1-2 在 PDX 模型中有效抑制腫瘤生長。
+
+> **嘻嘻**：PTCL 長期缺乏靶向治療，IGF2BP2 是新希望——既打腫瘤又改善免疫微環境，嘻嘻！
+
+---
+
+### Prognostic impact of FLT3-ITD microclones in young adults with acute myeloid leukemia treated with intensive chemotherapy
+**Authors**: Duployez N et al. | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.1182/blood.2025032829](https://doi.org/10.1182/blood.2025032829)
+**TL;DR**: 1,733 名新診斷 AML 的 post-hoc 分析，17.4% 的 non-macroclone 患者具有 FLT3-ITD microclones（allelic ratio 0.0004–0.05）。Microclones 獨立預測復發風險增加（sHR 1.50），與 macroclones（sHR 1.98–2.33）相當。2 年累積復發率：microclone 45.1%、macroclone 42.5%、無 FLT3-ITD 29.4%。41.8% microclone 患者復發時演變為 macroclone。
+
+> **不嘻嘻**：連微量的 FLT3-ITD 複製株都已夠危險——NGS 偵測在 AML 診斷中勢在必行，不嘻嘻（但知道比不知道好）！
+
+---
+
+### Biallelic loss-of-function mutations in BPNT1 cause vitamin B12-dependent megaloblastic anemia
+**Authors**: Zeng YH et al. | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.1182/blood.2026033550](https://doi.org/10.1182/blood.2026033550)
+**TL;DR**: 三名患者具有 BPNT1 雙等位基因功能喪失突變，表現為反覆發生的維生素 B12 依賴性 megaloblastic anemia。機制：BPNT1 缺乏導致 PAP（3'-phosphoadenosine 5'-phosphate）堆積、核糖體生合成受損，以及迴腸 cubam 受體複合物表現下降（Bpnt1-null 小鼠模型）。
+
+> **嘻嘻**：B12 缺乏的新遺傳原因現形！找到罕見病的成因總是令人振奮——嘻嘻！
+
+---
+
+### Chromosome 5q deletion drives evolution of aneuploidy in myeloid neoplasms with complex karyotype
+**Authors**: Creamer JP et al. | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.1182/blood.2025031996](https://doi.org/10.1182/blood.2025031996)
+**TL;DR**: iPSC 模型追蹤染色體演化顯示，同時具有 TP53 突變與 del(5q) 的 HSPC 在短暫有絲分裂抑制後，能逐步獲得 complex karyotype AML（AML-CK）特徵的複雜染色體異常；單有 TP53 突變則不足以驅動此過程。異倍體 HSPC 呈 BCL2 上調，venetoclax 可消滅此類複製株，但抗性株出現並上調其他 BCL2 家族蛋白。
+
+> **不嘻嘻**：del(5q) 不只是被動標記，而是主動推動染色體大亂——venetoclax 有用但魔高一丈——不嘻嘻（但機制研究很嘻嘻）！
+
+---
+
+### No overall increased risk of death in individuals with sickle cell trait: a study of 467 779 general population adults
+**Authors**: Warny M et al. | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.1182/blood.2025031872](https://doi.org/10.1182/blood.2025031872)
+**TL;DR**: 英國生物銀行 467,779 名成年人追蹤中位 15 年，SCT（sickle cell trait）攜帶者（n=1,253）整體死亡風險不增（HR 1.04），但糖尿病（HR 1.30）、慢性腎臟病（HR 1.46）及高血壓（OR 1.24）風險增加。SCT 合併糖尿病者心血管死亡風險顯著增加（HR 2.17）。以醫院登記診斷定義 SCT 的研究顯示較高風險，可能源於選擇偏差。
+
+> **不嘻嘻**：SCT 不是「只是帶因者、沒關係」——若同時有糖尿病，心血管死亡風險倍增——不嘻嘻！臨床上要更積極追蹤這群人。
+
+---
+
+### Anti-BCMA/GPRC5D CAR T in relapsed or refractory multiple myeloma patients with extraosseous extramedullary disease
+**Authors**: Zhou D et al. | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.1182/blood.2026033506](https://doi.org/10.1182/blood.2026033506)
+**TL;DR**: Phase 2 單臂研究，37 名有骨外骨髓外疾病（extraosseous EMD）的復發/難治多發性骨髓瘤（RRMM）患者接受抗 BCMA/GPRC5D 雙特異性 CAR T 治療（2×10⁶/kg）。整體有效率 97%，43% 達 stringent CR，MRD 陰性率 97%。中位 PFS 5.8 個月，中位 OS 未達。CRS 均為 1–2 級，ICANS 2 例。
+
+> **嘻嘻**：extraosseous EMD 是骨髓瘤最棘手的情境之一，97% 有效率令人振奮——嘻嘻！
+
+---
+
+### IV iron for IDA during acute infection
+**Authors**: （無作者資訊） | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.1182/blood.2026034127](https://doi.org/10.1182/blood.2026034127)
+**TL;DR**: （無摘要 — 無法定位完整內容）急性感染期間靜脈注射鐵劑治療缺鐵性貧血（IDA）的相關討論。
+
+> **嘻嘻**：感染期間補鐵——傳統觀念擔心細菌也利用鐵，但現代研究顯示可能沒那麼危險——嘻嘻（謹慎版）！
+
+---
+
+### Thymoma-associated aplastic anemia with concurrent Good syndrome
+**Authors**: Holland H et al. | **Type**: Journal Article | **Date**: 2026-05-21
+**DOI**: [10.1182/blood.2025031953](https://doi.org/10.1182/blood.2025031953)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）報告胸腺瘤相關性再生不良性貧血（aplastic anemia）合併 Good syndrome（胸腺瘤相關性免疫缺乏）的罕見病例。
+
+> **不嘻嘻**：胸腺瘤一次打三個（AA + Good syndrome + 免疫缺乏）——稀有到讓人拍桌——不嘻嘻（對病人）！
+
+---
+
+### TGFβ-PDL1 signaling in neutrophils preserves lung barrier during hyperinflammation
+**Authors**: Li Z et al. | **Type**: Journal Article | **Date**: 2026-05-19
+**DOI**: [10.1182/blood.2025031635](https://doi.org/10.1182/blood.2025031635)
+**TL;DR**: 在創傷/急性肺損傷高炎症動物模型中，TGFβ 信號維持 neutrophil 上的 PDL1 表現，限制過度活化並保護肺屏障。破壞 TGFβ 信號雖恢復 neutrophil 移行能力，但造成嚴重肺損傷；neutrophil 特異性 PDL1 剔除則能在減少病理性過度活化的同時，恢復有效殺菌功能。
+
+> **嘻嘻**：Neutrophil 也有免疫檢查點！TGFβ-PDL1 軸是高炎症狀態下維持平衡的關鍵——機制很精彩，嘻嘻！
+
+---
+
+### Consensus Recommendations for CAR T-Cell Administration in Adult Acute Lymphoblastic Leukemia: a Modified Delphi Study
+**Authors**: Muffly L et al. | **Type**: Journal Article | **Date**: 2026-05-19
+**DOI**: [10.1182/blood.2026033559](https://doi.org/10.1182/blood.2026033559)
+**TL;DR**: ROCCA 聯盟 9 位專家透過修正式 Delphi 研究，針對成人 B-ALL CAR-T 治療制定 33 條共識建議（初始 58 條），涵蓋患者選擇、橋接化療、淋巴耗竭、毒性管理、治療後監測及 CAR-T 後鞏固/維持療法等議題。
+
+> **嘻嘻**：終於有 CAR-T in adult ALL 的實踐共識了——雖然 Delphi 共識永遠讓人半信半疑，但有總比沒有好——嘻嘻！
+
+---
+
+### Inhibition of the Atypical Kinase WNK1 as a Therapeutic Strategy in TAL-related T-cell Acute Lymphoblastic Leukemia
+**Authors**: Montanaro A et al. | **Type**: Journal Article | **Date**: 2026-05-19
+**DOI**: [10.1182/blood.2025029901](https://doi.org/10.1182/blood.2025029901)
+**TL;DR**: 整合磷酸蛋白質組學與基因組學，發現 WNK1（非典型 serine/threonine 激酶，With No Lysine）在 TAL1/2 相關 T-ALL 亞型過度表現且為腫瘤生長所必需。WNK1 抑制誘導多倍體化及有絲分裂異常；其獨特 ATP 結合口袋（以 Cys 取代 Lys）為開發高選擇性小分子提供機會。
+
+> **嘻嘻**：T-ALL 靶向治療選項少，WNK1 是令人期待的新靶點——名字「With No Lysine」也很有記憶點，嘻嘻！
+
+---
+
+### Stag2 dependent chromatin remodeling enforces the erythroid-specific Gata1 cistrome
+**Authors**: Sudunagunta VS et al. | **Type**: Journal Article | **Date**: 2026-05-18
+**DOI**: [10.1182/blood.2025030554](https://doi.org/10.1182/blood.2025030554)
+**TL;DR**: Stag2（cohesin 成員，MDS 常見突變靶標）缺失改變染色質開放性，使 GATA1 在紅系細胞中的結合位點從紅系標的重新分配至巨核系標的（Fli1 motif），造成紅系分化缺陷及巨核系分化增加。此表型在人類 MDS 患者模型中均獲重現，提示 GATA1 結合特異性由染色質開放性決定。
+
+> **嘻嘻**：Stag2 突變扭轉了紅血球的命運，GATA1 被迫「投靠」巨核系——機制深刻而優雅，嘻嘻！
+
+---
+
+## N Engl J Med
+
+### Cardiovascular Risk Factors — Hypertension
+**Authors**: Biola H et al. | **Type**: Perspective | **Date**: 2026-05-20
+**DOI**: [10.1056/NEJMp2516850](https://doi.org/10.1056/NEJMp2516850)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）有關心血管危險因子——高血壓主題的 Perspective。
+
+> **不嘻嘻**：高血壓老面孔，永遠的頭號殺手——不嘻嘻！
+
+---
+
+### Money and Misdiagnosis: ITT Episode 2.3
+**Authors**: （無作者資訊） | **Type**: Multimedia | **Date**: 2026-05-20
+**DOI**: [10.1056/NEJMp2601976](https://doi.org/10.1056/NEJMp2601976)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）NEJM 播客《Is That Thing Alive》第 2 季第 3 集，探討金錢與誤診的關係。
+
+> **嘻嘻**：醫學播客入 PubMed——這個時代什麼都要有 PMID！
+
+---
+
+### Advancing Indigenous Health Equity in Medical School Curricula
+**Authors**: Nelson J et al. | **Type**: Perspective | **Date**: 2026-05-20
+**DOI**: [10.1056/NEJMp2605243](https://doi.org/10.1056/NEJMp2605243)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）倡議在醫學院課程中融入原住民健康公平議題。
+
+> **嘻嘻**：醫學教育需要更多元視角——嘻嘻！
+
+---
+
+### Childhood Vaccine Hesitancy
+**Authors**: O'Leary ST et al. | **Type**: Review | **Date**: 2026-05-20
+**DOI**: [10.1056/NEJMcp2516616](https://doi.org/10.1056/NEJMcp2516616)
+**TL;DR**: 回顧兒童疫苗猶豫（vaccine hesitancy）的應對策略。多數猶豫的家長仍有保護孩子的動機，主要顧慮為安全性。臨床醫師是最受信賴的疫苗資訊來源；假設式溝通法（presumptive approach）比開放式詢問更有效；動機式晤談（motivational interviewing）有助建立信任並回應錯誤資訊。
+
+> **嘻嘻**：醫師說「你的孩子今天要打疫苗了」比問「你要不要打疫苗？」效果好太多——溝通心理學嘻嘻版！
+
+---
+
+### Prehospital Resuscitation with Type O Whole Blood for Trauma and Hemorrhage
+**Authors**: Sperry JL et al. | **Type**: Original Article | **Date**: 2026-05-18
+**DOI**: [10.1056/NEJMoa2602167](https://doi.org/10.1056/NEJMoa2602167)
+**TL;DR**: 多中心 phase 3 叢集隨機試驗，44 個航空醫療基地 2:1 分配至 whole blood 或成分輸血（plasma + 紅血球）。共 1,020 名創傷患者，30 天死亡率：whole blood 組 25.9% vs 成分輸血 20.5%（調整 OR 1.24，P=0.24），未顯示 whole blood 優越性。儲存時間長短對預後亦無影響。
+
+> **不嘻嘻**：Whole blood 大戰成分輸血——whole blood 沒贏，甚至輸了一點點——不嘻嘻！大型試驗有時就是這樣讓人失望。
+
+---
+
+### Phase 3 Trials of Inhaled Treprostinil for Idiopathic Pulmonary Fibrosis
+**Authors**: Nathan SD et al. | **Type**: Original Article | **Date**: 2026-05-18
+**DOI**: [10.1056/NEJMoa2501488](https://doi.org/10.1056/NEJMoa2501488)
+**TL;DR**: TETON-1 phase 3 隨機試驗（598 名 IPF 患者），吸入 treprostinil vs 安慰劑 52 週。主要終點 FVC 變化量：treprostinil 中位 -43.3 mL vs 安慰劑 -196.2 mL（差異 130.1 mL，P<0.001）。臨床惡化（死亡/呼吸住院/FVC ≥10% 相對下降）：31.8% vs 44.5%（HR 0.67，P=0.003）。主要副作用為咳嗽（54.8% vs 33.1%）。
+
+> **嘻嘻**：IPF 又多了一個有效武器！Treprostinil 讓肺功能保留更好——嘻嘻！只是咳嗽副作用不太友善。
+
+---
+
+### Azithromycin for Preschoolers with Wheezing in the Emergency Department
+**Authors**: Denninghoff KR et al. | **Type**: Original Article | **Date**: 2026-05-18
+**DOI**: [10.1056/NEJMoa2516505](https://doi.org/10.1056/NEJMoa2516505)
+**TL;DR**: 多中心隨機試驗，840 名 18–59 個月幼兒因中重度喘鳴至急診，隨機接受 azithromycin（12 mg/kg/day × 5 天）或安慰劑。521 名（62%）鼻咽細菌培養陽性。資料安全監察委員會因無效提早終止。兩組在 ADYC 喘鳴症狀評分無顯著差異（不論陽性或陰性隊列）。細菌清除率：azithromycin 58.7% vs 安慰劑 11.4%——清除了細菌但症狀沒改善。
+
+> **不嘻嘻**：把細菌清光了，喘鳴照舊——細菌也許只是旁觀者，不是病因——不嘻嘻！抗生素濫用少一個理由，倒是好消息？
+
+---
+
+## NEJM Monthly — Infectious Disease（May 2026）
+
+> 資料來源：Gmail（Infectious Disease Update from NEJM，發行日 May 2026）。補完 PubMed N Engl J Med section 之外的 Cases / Images / Perspective / Correspondence 等，無主題過濾。
+
+### A Multicomponent Intervention to Improve Maternal Infection Outcomes
+**Authors**: Lissauer D et al. | **Type**: Original Article | **Date**: 2026-04-30
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dab2&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: 叢集隨機試驗於馬拉威及烏干達 59 家衛生機構推行 APT-Sepsis 多元介入方案（手衛生、感控最佳實踐、FAST-M 敗血症早期識別包）。主要終點（感染相關孕產婦死亡或嚴重感染）：介入組 1.4% vs 常規護理 1.9%（RR 0.68，95% CI 0.55–0.83，P<0.001）。
+
+> **嘻嘻**：回歸基本功（洗手、早期識別、正確用藥）就能顯著降低孕產婦感染死亡——嘻嘻，而且超划算！
+
+---
+
+### Pulmonary Tuberculosis Detection with MiniDock MTB Using Swab Samples
+**Authors**: Yerlikaya S et al. | **Type**: Original Article | **Date**: 2026-04-30
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dab6&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: MiniDock MTB 以痰液靈敏度 85.7%、舌頭拭子 79.6%，兩者特異性均 >97.5%。痰液靈敏度媲美 Xpert MTB/RIF Ultra，優於塗片鏡檢（高 24.3 個百分點）。符合 WHO 結核診斷準確性及使用性目標。
+
+> **嘻嘻**：不需要痰，只要舌頭拭子就能診斷結核——對不會咳痰的病人是救星——嘻嘻！
+
+---
+
+### Balanced Fluid or 0.9% Saline in Children Treated for Septic Shock
+**Authors**: Balamuth F et al. | **Type**: Original Article | **Date**: 2026-04-24
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dab7&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: 47 個急診多國實用隨機試驗，小兒疑似敗血性休克患者接受均衡液（balanced fluid）或 0.9% 生理食鹽水輸液復甦 48 小時。主要終點（30 天重大腎臟不良事件）：balanced fluid 3.4% vs 0.9% saline 3.0%（差異 0.4 個百分點，P=0.85），兩者無顯著差異。
+
+> **嘻嘻**：成人資料說均衡液好一點點，兒科這邊說沒差——生理食鹽水的冤案又洗白了一些，嘻嘻（或不嘻嘻，取決於你押哪邊）！
+
+---
+
+### Oral Nirmatrelvir–Ritonavir for Covid-19 in Higher-Risk Outpatients
+**Authors**: Butler CC et al. | **Type**: Original Article | **Date**: 2026-04-23
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dab8&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: PANORAMIC（英國）及 CanTreatCOVID（加拿大）兩個開放標籤平台試驗，已接種疫苗的高風險 COVID-19 陽性成人，nirmatrelvir-ritonavir 未能降低住院或死亡率（PANORAMIC：0.8% vs 0.7%；CanTreatCOVID：0.6% vs 1.2%）。
+
+> **不嘻嘻**：Paxlovid 在接種疫苗的現代世界效果不如預期——已接種族群的基礎保護已夠好，藥物加成空間有限——不嘻嘻（對 Pfizer 的股價而言）！
+
+---
+
+### Selective Decontamination of the Digestive Tract during Ventilation in the ICU
+**Authors**: The SuDDICU Investigators | **Type**: Original Article | **Date**: 2026-04-16
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dabc&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: 26 個 ICU 共 9,289 名機械通氣患者，SDD（選擇性腸道去污）vs 標準護理。90 天死亡率：SDD 27.9% vs 29.5%（OR 0.94，P=0.27），無顯著差異。但 SDD 組新發血流感染（4.9% vs 6.8%）及抗藥性菌定植（16.8% vs 26.8%）均較少。
+
+> **嘻嘻**：SDD 沒降死亡率，但感染率和抗藥性菌都少了——介於嘻嘻和不嘻嘻之間的曖昧地帶！
+
+---
+
+### Immunogenicity and Safety of vYF, a Yellow Fever Vaccine — A Phase 2 Trial
+**Authors**: Feroldi E et al. | **Type**: Original Article | **Date**: 2026-04-09
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dac0&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: 新型黃熱病疫苗 vYF 與現行 YF-VAX 免疫原性相當（第 29 天血清轉換率 99.7% vs 99.4%，非劣性成立），中和抗體幾何平均效價相近，安全性無重大顧慮。
+
+> **嘻嘻**：多一個黃熱病疫苗選項，在供應緊張時是好消息——嘻嘻！
+
+---
+
+### Tuberculosis Cases and Deaths Averted by PEPFAR
+**Authors**: （無作者資訊） | **Type**: Correspondence | **Date**: 2026-04-23
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dac3&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）估算 PEPFAR 計畫對結核病病例預防及死亡避免的貢獻。
+
+> **不嘻嘻**：PEPFAR 削減是當前時事，對其縮減的憂慮透過此信件可見一斑——不嘻嘻！
+
+---
+
+### Risk of Guillain–Barré Syndrome after Laboratory-Confirmed Dengue Infection
+**Authors**: （無作者資訊） | **Type**: Correspondence | **Date**: 2026-04-16
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dac4&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）評估實驗室確認登革熱感染後 Guillain–Barré syndrome（GBS）的發生風險。
+
+> **不嘻嘻**：登革熱之後還要擔心 GBS——熱帶病永遠有你想不到的後遺症——不嘻嘻！
+
+---
+
+### Spinal Epidural Abscess
+**Authors**: Tande AJ, Currier BL, Osmon DR | **Type**: Review Article | **Date**: 2026-04-23
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dac5&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: 脊椎硬膜外膿瘍（SEA）綜述，典型表現為局部背/頸部疼痛合併發燒或神經症狀，MRI 加顯影劑為首選診斷工具。Staphylococcus aureus 占逾 50% 病原。所有患者均應緊急請脊椎外科及感染科共同評估。
+
+> **嘻嘻**：SEA 罕見但嚴重，早期識別和多科介入是關鍵——嘻嘻（臨床實用知識回顧）！
+
+---
+
+### Case 13-2026: A 76-Year-Old Woman with Fatigue, Rash, and Kidney Failure
+**Authors**: Cortazar FB et al. | **Type**: Case Records of the Massachusetts General Hospital | **Date**: 2026-04-30
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dac6&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）76 歲女性，疲勞、皮疹及腎衰竭的 MGH 病例記錄。
+
+> **嘻嘻**：三聯症：疲勞 + 皮疹 + 腎衰竭——鑑別診斷好豐富，MGH case 永遠吊人胃口——嘻嘻！
+
+---
+
+### Case 12-2026: An 86-Year-Old Woman with Anorexia, Weight Loss, and Liver Lesions
+**Authors**: Chapman MM et al. | **Type**: Case Records of the Massachusetts General Hospital | **Date**: 2026-04-23
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dac7&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）86 歲女性，食慾不振、體重減輕及肝臟病灶的 MGH 病例記錄。
+
+> **嘻嘻**：老年人的肝臟病灶，鑑別清單又長又複雜——偵探醫學嘻嘻！
+
+---
+
+### Mycetoma
+**Authors**: （無作者資訊） | **Type**: Images in Clinical Medicine | **Date**: （無日期）
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dac9&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）黴菌腫（mycetoma）的臨床影像病例，被忽視熱帶疾病之一。
+
+> **不嘻嘻**：Mycetoma 是熱帶地區的「被忽視疾病」，腫腫的、治療困難——不嘻嘻！
+
+---
+
+### Vibrio vulnificus Necrotizing Soft-Tissue Infection
+**Authors**: （無作者資訊） | **Type**: Images in Clinical Medicine | **Date**: （無日期）
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dacb&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）Vibrio vulnificus 壞死性軟組織感染（NSTI）的臨床影像。
+
+> **不嘻嘻**：吃了生海鮮或傷口碰到海水，就可能讓肉被吃光——夏天最恐怖的提醒——不嘻嘻！
+
+---
+
+### Intraosseous Abscess from Subacute Osteomyelitis
+**Authors**: （無作者資訊） | **Type**: Images in Clinical Medicine | **Date**: （無日期）
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dacd&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）亞急性骨髓炎（osteomyelitis）骨內膿瘍（Brodie's abscess）影像病例。
+
+> **嘻嘻**：骨頭裡面也能長膿包——影像診斷課嘻嘻！
+
+---
+
+### Minocycline-Induced Hyperpigmentation
+**Authors**: （無作者資訊） | **Type**: Images in Clinical Medicine | **Date**: （無日期）
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dacf&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）Minocycline 引起的皮膚色素沉著（hyperpigmentation）臨床影像。
+
+> **不嘻嘻**：Minocycline 開著開著皮膚變色——副作用警示，吃藥前先說清楚——不嘻嘻！
+
+---
+
+### Double Take: The Devil Is in the Details
+**Authors**: （無作者資訊） | **Type**: Perspective | **Date**: （無日期）
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dad1&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — 無法定位 PubMed/CrossRef 紀錄）
+
+> **嘻嘻**：細節決定成敗，醫學永遠如此——嘻嘻！
+
+---
+
+### Tackling Maternal Sepsis — Doing the Basics, and Doing Them Well
+**Authors**: Berkley JA | **Type**: Editorial | **Date**: 2026-04-30
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dad2&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）APT-Sepsis 試驗配套社論，討論在低中收入國家落實孕產婦敗血症基本救治的路徑。
+
+> **嘻嘻**：「做基本功，做得好」——最簡單的建議往往最有力——嘻嘻！
+
+---
+
+### Shock Not Advised
+**Authors**: Rourke E | **Type**: Perspective | **Date**: 2026-04-30
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dad3&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）個人敘事型 Perspective，標題語帶雙關。
+
+> **嘻嘻**：Shock Not Advised——是醫學建議還是人生哲學？——嘻嘻！
+
+---
+
+### Legislating Medicine — Directed Donation and the Politics of Patient Choice
+**Authors**: Jacobs JW et al. | **Type**: Perspective | **Date**: 2026-04-30
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dad6&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）討論定向捐血/器官捐贈的立法與病人選擇政治面向。
+
+> **嘻嘻**：病人可以指定輸誰的血？複雜的倫理與法律問題——嘻嘻（思考題）！
+
+---
+
+### Anticompetitive Mergers — Pharmaceutical Buyouts as a Strategy for Maintaining Market Dominance
+**Authors**: Tu SS, King J | **Type**: Perspective | **Date**: 2026-04-23
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dad7&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）分析製藥公司收購競爭對手作為維持市場主導地位策略的反競爭面向。
+
+> **不嘻嘻**：大藥廠把小藥廠買走再把藥收起來——這就是為什麼藥越來越貴——不嘻嘻！
+
+---
+
+### Same Pill, Different Impact — Reassessing the Efficacy of Nirmatrelvir–Ritonavir
+**Authors**: Lane HC, Fauci AS | **Type**: Editorial | **Date**: 2026-04-23
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dad8&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）Lane 與 Fauci 針對 nirmatrelvir–ritonavir 在不同族群療效差異的社論評析。
+
+> **嘻嘻**：Fauci 退休後仍然筆耕不輟——前 NIAID 主任的書目依然可觀——嘻嘻！
+
+---
+
+### Selective Digestive Decontamination — Finding the Way Forward
+**Authors**: Klompas M | **Type**: Editorial | **Date**: 2026-04-16
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dad9&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）SDD 大型試驗配套社論，Klompas 討論如何在實踐中推進 SDD 應用。
+
+> **嘻嘻**：大試驗說死亡率沒差，但感染和抗藥性菌都少了——Klompas 怎麼看？期待內文嘻嘻！
+
+---
+
+### Not Otherwise Specified — Season 3: The Forever Crisis of Primary Care — NOS Episode 3.12
+**Authors**: （無作者資訊） | **Type**: Perspective | **Date**: 2026-04-16
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dada&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — 無法定位 PubMed/CrossRef 紀錄）NEJM 播客《Not Otherwise Specified》S3E12，探討基層醫療的永恆危機。
+
+> **不嘻嘻**：基層醫療危機嚴重到要出一整季播客——不嘻嘻（對基層醫療現況）！
+
+---
+
+### The Dismantling of Environmental Protections — A Grave Threat to America's Health
+**Authors**: Gaffney AW et al. | **Type**: Perspective | **Date**: 2026-04-16
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dadb&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）討論環境保護政策遭破壞對美國公共健康的嚴重威脅。
+
+> **不嘻嘻**：環境政策即健康政策——NEJM 說話了——不嘻嘻（對環境的深切憂慮）！
+
+---
+
+### Nurse Scientists as Trusted Voices in Health Communication
+**Authors**: Joseph P et al. | **Type**: Perspective | **Date**: 2026-04-16
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf78a8f2,8e24a14,3f2dadc&cid=DM2448252_Non_Subscriber&bid=-814176014&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）倡議護理科學家在健康傳播中扮演更重要的可信聲音角色。
+
+> **嘻嘻**：護理師說的話，病人也許更願意聽——跨科際合作嘻嘻！
+
+---
+
+## NEJM Monthly — Hematology/Oncology（May 2026）
+
+> 資料來源：Gmail（Hematology/Oncology Update from NEJM，發行日 May 2026）。補完 PubMed N Engl J Med section 之外的 Cases / Images / Perspective / Correspondence 等。已濾除標題含 cancer / carcinoma 之篇目。
+
+### Mim8 Bispecific Antibody Prophylaxis in Hemophilia A with or without Inhibitors
+**Authors**: Mancuso ME et al. | **Type**: Original Article | **Date**: 2026-04-30
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd22&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: 血友病 A（有或無 FVIII inhibitor）患者，mim8（denecimig，bispecific antibody mimicking activated FVIII）每週或每月皮下注射 vs 按需輸注。年化出血事件率：每週給藥 0.57、每月給藥 0.20，vs 按需 15.76（相對降低 96.4% 及 98.7%，P<0.001 for both）。
+
+> **嘻嘻**：血友病 A 又有新武器！Mim8 每月一次就讓出血事件降低 98.7%——嘻嘻！
+
+---
+
+### Asundexian for Secondary Stroke Prevention
+**Authors**: Sharma M et al. | **Type**: Original Article | **Date**: 2026-04-16
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd2d&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: 口服 factor XIa 抑制劑 asundexian 用於非心源性栓塞性缺血性中風或 TIA 的二級預防試驗（PMID 41985132），評估是否優於現有抗血小板治療。
+
+> **嘻嘻**：Factor XIa 抑制劑出血風險可能較低——中風二級預防的新方向，嘻嘻！
+
+---
+
+### Ianalumab plus Eltrombopag in Immune Thrombocytopenia
+**Authors**: Cuker A et al. | **Type**: Original Article | **Date**: 2026-04-16
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd31&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: 評估 ianalumab（抗 B 細胞 BAFF-R 單株抗體）合併 eltrombopag 是否能誘發免疫性血小板低下症（ITP）的無藥物緩解（drug-free remission）。ITP 最惱人的就是要長期服藥，能真正緩解才是目標。
+
+> **嘻嘻**：ITP 追求無藥物緩解——能達到的話就嘻嘻了！
+
+---
+
+### A Phase 2 Randomized Trial of Mezagitamab in Primary Immune Thrombocytopenia
+**Authors**: Kuter DJ et al. | **Type**: Original Article | **Date**: 2026-04-09
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd34&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: Phase 2 隨機試驗，抗 CD38 單株抗體 mezagitamab 用於原發性 ITP，評估療效與安全性。CD38 抑制劑從多發性骨髓瘤跨界到血小板疾病。
+
+> **嘻嘻**：ITP 新武器繼續湧現——CD38 抑制劑的適應症越來越廣——嘻嘻！
+
+---
+
+### CRISPR-Cas12a Gene Editing of HBG1 and HBG2 Promoters to Treat Sickle Cell Disease
+**Authors**: Hanna R et al. | **Type**: Original Article | **Date**: 2026-04-02
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd3c&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: 研究性 CRISPR-Cas12a 基因編輯自體 HSPC 療法 reni-cel，靶向 HBG1/HBG2 啟動子重新活化胎兒血紅素（HbF）以治療鐮刀型紅血球病（SCD）。臨床試驗初步結果顯示持久的 HbF 誘導及臨床獲益。
+
+> **嘻嘻**：CRISPR 正式進入 SCD 治療——基因編輯讓 HbF「重出江湖」——嘻嘻！
+
+---
+
+### CRISPR-Cas12a Gene Editing of HBG1 and HBG2 Promoters to Treat β-Thalassemia
+**Authors**: Frangoul H et al. | **Type**: Original Article | **Date**: 2026-04-02
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd40&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: 同樣的 reni-cel CRISPR-Cas12a 基因編輯療法應用於 β-地中海型貧血，重新活化 HbF，使患者擺脫輸血依賴。
+
+> **嘻嘻**：一個療法同時攻克 SCD 和 β-thalassemia——嘻嘻到最高點！
+
+---
+
+### Base Editing of HBG1 and HBG2 Promoters for Sickle Cell Disease
+**Authors**: Gupta AO et al. | **Type**: Original Article | **Date**: 2026-04-01
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd44&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: Ristoglogene autogetemcel（risto-cel）以 base editing 技術靶向 HBG1/HBG2 啟動子，重新活化 HbF 治療 SCD，是 CRISPR 之外的另一個基因編輯選項。
+
+> **嘻嘻**：CRISPR 不夠，Base Editing 也來了——血紅素疾病基因療法百花齊放——嘻嘻！
+
+---
+
+### CD19 CAR T-Cell Therapy for Treatment of Chronic Graft-versus-Host Disease
+**Authors**: （無作者資訊） | **Type**: Correspondence | **Date**: 2026-04-30
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd47&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）CD19 CAR T 細胞療法用於慢性移植物抗宿主疾病（cGVHD）的臨床經驗報告。
+
+> **嘻嘻**：CAR-T 跨界治 cGVHD！免疫療法的疆界越來越廣——嘻嘻！
+
+---
+
+### Hepatic Pseudoprogression after Treatment with Nectin-4–Targeted Antibody–Drug Conjugate
+**Authors**: （無作者資訊） | **Type**: Correspondence | **Date**: 2026-04-16
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd48&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）報告 Nectin-4 靶向 ADC（antibody-drug conjugate）治療後的肝臟假性進展（hepatic pseudoprogression）現象。
+
+> **不嘻嘻**：ADC 治療後肝臟「變大」，差點以為惡化——假性進展嚇死人——不嘻嘻！
+
+---
+
+### Barrett's Esophagus
+**Authors**: Fitzgerald RC | **Type**: Clinical Practice | **Date**: 2026-04-30
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd49&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: Barrett's esophagus 由慢性酸液及膽汁逆流引起，增加食道腺癌風險。診斷需內視鏡（≥1 cm 柱狀上皮）及病理（腸型化生含杯狀細胞）確認。監測聚焦於高惡性度不典型增生及早期癌症的早期偵測。
+
+> **嘻嘻**：這明明是消化科文章怎麼跑進 Hema/Onc 月報——不嘻嘻（分類）！但對有胃食道逆流的讀者很實用——嘻嘻！
+
+---
+
+### Sex Hormone Influences on Venous Thrombotic and Cardiovascular Risk
+**Authors**: Skeith L, Bates SM | **Type**: Review Article | **Date**: 2026-04-16
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd4a&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: 系統回顧性文章，探討性荷爾蒙（避孕藥、HRT、性別認同荷爾蒙治療、輔助生殖等）對凝血系統與血管的影響，以及相關靜脈血栓風險，涵蓋荷爾蒙劑型、血栓傾向、既往血栓史及常見臨床因素。
+
+> **嘻嘻**：性荷爾蒙與血栓的關係繁複，這篇 review 幫整理了一遍——臨床實用，嘻嘻！
+
+---
+
+### Membranoproliferative Glomerulonephritis Due to Cryoglobulinemia
+**Authors**: （無作者資訊） | **Type**: Images in Clinical Medicine | **Date**: （無日期）
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd4c&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）冷球蛋白血症引起的膜增生性腎絲球腎炎（MPGN）臨床影像。
+
+> **嘻嘻**：冷球蛋白血症的腎臟表現——HCV、淋巴瘤、或其他系統性疾病的診斷線索——嘻嘻！
+
+---
+
+### Necrolytic Migratory Erythema
+**Authors**: （無作者資訊） | **Type**: Images in Clinical Medicine | **Date**: （無日期）
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd4e&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）壞死性遊走性紅斑（necrolytic migratory erythema，NME）臨床影像，為 glucagonoma 的特徵性皮膚表現。
+
+> **不嘻嘻**：看到奇怪皮疹記得想到胰臟腫瘤——不嘻嘻（對胰臟而言）！
+
+---
+
+### Science behind the Study: A Second Factor VIIIa Mimetic for Hemophilia A
+**Authors**: Srivastava A | **Type**: Editorial | **Date**: 2026-04-30
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd4f&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）針對 mim8 試驗機制背景的「Science behind the Study」特別社論。
+
+> **嘻嘻**：NEJM 解說科學背後的故事——科普版嘻嘻！
+
+---
+
+### EGFR's Poor Sibling
+**Authors**: Carbone DP | **Type**: Editorial | **Date**: 2026-04-30
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd50&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — 無法定位 PubMed/CrossRef 紀錄）
+
+> **嘻嘻**：EGFR 的窮兄弟是誰——HER2？HER3？讀了才知道——好奇心版嘻嘻！
+
+---
+
+### Asundexian for Noncardioembolic Ischemic Stroke
+**Authors**: Boulanger M | **Type**: Editorial | **Date**: 2026-04-16
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd53&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）Asundexian 中風二級預防試驗的配套社論。
+
+> **嘻嘻**：Factor XIa 抑制劑在中風預防的前景——嘻嘻！
+
+---
+
+### The Dismantling of Environmental Protections — A Grave Threat to America's Health
+**Authors**: Gaffney AW et al. | **Type**: Perspective | **Date**: 2026-04-16
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd54&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）討論環境保護政策遭破壞對美國公共健康的嚴重威脅。
+
+> **不嘻嘻**：環境政策即健康政策——不嘻嘻（對環境的深切憂慮）！
+
+---
+
+### Stenting for Post-Thrombotic Syndrome — A Step Forward
+**Authors**: Flumignan RLG, Nakano LCU | **Type**: Editorial | **Date**: 2026-04-13
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd55&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）深靜脈血栓後症候群（post-thrombotic syndrome）支架治療進展的社論。
+
+> **嘻嘻**：PTS 治療又往前一步——嘻嘻！
+
+---
+
+### More Options for Gene Editing in Hemoglobinopathies
+**Authors**: Locatelli F | **Type**: Editorial | **Date**: 2026-04-02
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd57&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — PubMed 此類型無 abstract）評論血紅素疾病基因編輯療法多元選項的社論（對應 reni-cel 及 risto-cel 試驗）。
+
+> **嘻嘻**：選擇越來越多——病人和醫師可以有更個人化的選項——嘻嘻！
+
+---
+
+### Enfortumab Vedotin plus Pembrolizumab as Perioperative Therapy
+**Authors**: Singh P, Lerner SP | **Type**: Editorial | **Date**: 2026-04-02
+[**NEJM Newsletter**](https://t.n.nejm.org/r/?id=hcf8b102f,8e266cf,3f2dd58&cid=DM2448259_Non_Subscriber&bid=-812969937&p1=U2FsdGVkX18D%2BJS4RGDnD8Krl1P2lqhXjUh799GALmaTKXvzn8EWcuZiqPUmxcwdkjClQ6Lc3lnqZRloqX6cjArE0IoyJxpsGOJSpNpRlmSEY4DBmGnfv7GAt5V1%2FbY9sBMXg3as%2FFf0f1F%2FBA4v5Cub%2F1dYKrn9VtnPrUBZeVcouiXzHriLyE%2Bow8A9fsRh1k5i5GHQ3KQsNDuhazqdYQ%3D%3D)
+**TL;DR**: （無摘要 — 無法定位 PubMed/CrossRef 紀錄）膀胱癌圍手術期 enfortumab vedotin + pembrolizumab 治療的社論。
+
+> **嘻嘻**：膀胱癌圍手術期治療新組合——嘻嘻！
+
+---
+
+*資料來源：PubMed（articles retrieved 2026-05-25）*
+*NEJM 月報資料來源：Gmail；abstract / DOI 由 PubMed 標題搜尋（fallback CrossRef）回查取得；newsletter body 不含 abstract，追蹤 URL 不可解析。*
+*注：Blood PMID 42166198 及 42166197 為 PubMed 更正紀錄（標題為被更正文章之引用），已從本摘要中排除。CrossRef 補全步驟因 UNPAYWALL_EMAIL 未設定而略過。*


### PR DESCRIPTION
## Summary
- Adds `docs/posts/2026-W21.md` — weekly ID & Hema journal digest for 2026-05-18 to 2026-05-24
- 39 PubMed articles (10 CID, 0 EID, 2 MMWR, 6 TID, 14 Blood, 7 NEJM)
- 45 newsletter items (25 NEJM ID Monthly + 20 NEJM Hema/Onc Monthly, May 2026)

https://claude.ai/code/session_01EESQe3Dgc9kwtan4XCyZPv

---
_Generated by [Claude Code](https://claude.ai/code/session_01EESQe3Dgc9kwtan4XCyZPv)_